### PR TITLE
Split points into buckets after overfilling

### DIFF
--- a/quadtree.js
+++ b/quadtree.js
@@ -133,7 +133,7 @@ class QuadTree {
     if (!this.divided) {
       this.points.push(point);
       
-      if (this.points.length > this.capacity) {      
+      if (this.points.length >= this.capacity) {      
         this.subdivide();
       }
     

--- a/quadtree.js
+++ b/quadtree.js
@@ -115,8 +115,14 @@ class QuadTree {
     this.southeast = new QuadTree(se, this.capacity);
     let sw = new Rectangle(x - w, y + h, w, h);
     this.southwest = new QuadTree(sw, this.capacity);
-
+    
     this.divided = true;
+    
+    for (let p of this.point) {
+      this.insert(p);
+    }
+    
+    this.points = null;
   }
 
   insert(point) {
@@ -124,13 +130,14 @@ class QuadTree {
       return false;
     }
 
-    if (this.points.length < this.capacity) {
-      this.points.push(point);
-      return true;
-    }
-
     if (!this.divided) {
-      this.subdivide();
+      this.points.push(point);
+      
+      if (this.points.length > this.capacity) {      
+        this.subdivide();
+      }
+    
+      return true;
     }
 
     if (this.northeast.insert(point) || this.northwest.insert(point) ||

--- a/quadtree.js
+++ b/quadtree.js
@@ -118,7 +118,7 @@ class QuadTree {
     
     this.divided = true;
     
-    for (let p of this.point) {
+    for (let p of this.points) {
       this.insert(p);
     }
     


### PR DESCRIPTION
This fixes a performance issue where a query is forced to check `quantity` nodes each level before last, in addition to the less-than `quantity` nodes in the leaves.