### PR TITLE
Add Closest Operation

### DIFF
--- a/examples/visualize_qtree/sketch.js
+++ b/examples/visualize_qtree/sketch.js
@@ -34,6 +34,13 @@ function draw() {
     stroke(0, 255, 0);
     strokeWeight(4);
     point(p.x, p.y);
+
+    let neighbors = qtree.closest(new Point(p.x, p.y), 8);
+    stroke(0, 255, 0, 50);
+    strokeWeight(1);
+    for (let n of neighbors) {
+      line(p.x, p.y, n.x, n.y);
+    }
   }
 }
 

--- a/quadtree.js
+++ b/quadtree.js
@@ -162,11 +162,13 @@ class QuadTree {
   }
 
   closest(point, count) {
-    if (!count) {
+    if (typeof count === "undefined") {
       count = 1;
     }
+    // Start with a circle 1/4 the size of the boundary
+    // 1/2 the size would be purer, but most final queries are smaller than that
     let size = Math.max(this.boundary.w, this.boundary.h) / 4;
-    let jump = size / 2;
+    let jump = size / 2; // what we change the size by
     let range = new Circle(point.x, point.y, size);
     let points = this.query(range);
     while (points.length !== count) {
@@ -175,6 +177,7 @@ class QuadTree {
         jump /= 2;
       } else {
         size += jump;
+        // don't halve jump when enlarging the query so we don't limit max size
       }
 
       range = new Circle(point.x, point.y, size);

--- a/quadtree.js
+++ b/quadtree.js
@@ -177,30 +177,24 @@ class QuadTree {
       }
     }
 
-    let low = 0;
-    // start with a circle that contains the whole tree
-    // binary search until we contain our desired count
-    let high = Math.pow((this.boundary.w / 2), 2) +
-               Math.pow((this.boundary.h / 2), 2);
-    let points;
-    let limit = 16; // Limit to prevent lock on ties
-    while (limit-- && low < high) {
-      let mid = (low + high) / 2;
-      let range = new Circle(point.x, point.y, mid);
-      points = this.query(range);
+    // optimized, expanding binary search
+    // start with a small circle, rapidly expand, slowly shrink
+    let radius = 1;
+    let limit = 16;
+    while (true) {
+      const range = new Circle(point.x, point.y, radius);
+      const points = this.query(range);
+      if (points.length > 0 && limit-- <= 0) {
+        return points.slice(0, count); 
+      }
       if (points.length === count) {
         return points; // Return when we hit the right size
-      } else if (points.length === 0) {
-        high *= 2;
       } else if (points.length < count) {
-        low = mid;
+        radius *= 2;
       } else {
-        high = mid;
+        radius /= 1.5;
       }
     }
-    // Break ties when we hit the limit
-    const final = new Circle(point.x, point.y, high);
-    return this.query(final).slice(0, count);
   }
 }
 

--- a/quadtree.js
+++ b/quadtree.js
@@ -178,7 +178,9 @@ class QuadTree {
     }
 
     let low = 0;
-    let high = Math.max(this.boundary.w, this.boundary.h);
+    // start with a circle that contains the whole tree
+    let high = Math.pow((this.boundary.w / 2), 2) +
+               Math.pow((this.boundary.h / 2), 2);
     let points;
     let limit = 16;
     while (limit-- && low < high) {

--- a/quadtree.js
+++ b/quadtree.js
@@ -161,7 +161,27 @@ class QuadTree {
     return found;
   }
 
+  closest(point, count) {
+    if (!count) {
+      count = 1;
+    }
+    let size = Math.max(this.boundary.w, this.boundary.h) / 4;
+    let jump = size / 2;
+    let range = new Circle(point.x, point.y, size);
+    let points = this.query(range);
+    while (points.length !== count) {
+      if (points.length > count) {
+        size -= jump;
+        jump /= 2;
+      } else {
+        size += jump;
+      }
+
+      range = new Circle(point.x, point.y, size);
+      points = this.query(range);
+    }
+    return points;
+  }
 }
 
 ((module ? module.exports = { Point, Rectangle, QuadTree, Circle } : 0));
-

--- a/quadtree.js
+++ b/quadtree.js
@@ -179,16 +179,17 @@ class QuadTree {
 
     let low = 0;
     // start with a circle that contains the whole tree
+    // binary search until we contain our desired count
     let high = Math.pow((this.boundary.w / 2), 2) +
                Math.pow((this.boundary.h / 2), 2);
     let points;
-    let limit = 16;
+    let limit = 16; // Limit to prevent lock on ties
     while (limit-- && low < high) {
       let mid = (low + high) / 2;
       let range = new Circle(point.x, point.y, mid);
       points = this.query(range);
       if (points.length === count) {
-        return points;
+        return points; // Return when we hit the right size
       } else if (points.length === 0) {
         high *= 2;
       } else if (points.length < count) {
@@ -197,8 +198,8 @@ class QuadTree {
         high = mid;
       }
     }
-    // Break ties
-    let final = new Circle(point.x, point.y, high);
+    // Break ties when we hit the limit
+    const final = new Circle(point.x, point.y, high);
     return this.query(final).slice(0, count);
   }
 }

--- a/quadtree.js
+++ b/quadtree.js
@@ -159,12 +159,19 @@ class QuadTree {
     }
 
     return found;
-<<<<<<< Updated upstream
   }
 
   closest(point, count) {
     if (typeof count === "undefined") {
       count = 1;
+    }
+    if (!this.divided) {
+      if (this.points.length == 0) {
+        return [];
+      }
+      if (this.points.length < count) {
+        count = this.points.length;
+      }
     }
     // Start with a circle 1/4 the size of the boundary
     // 1/2 the size would be purer, but most final queries are smaller than that
@@ -173,6 +180,11 @@ class QuadTree {
     let range = new Circle(point.x, point.y, size);
     let points = this.query(range);
     while (points.length !== count) {
+      // limit
+      if (jump < 1e-5 && points.length > count) {
+        return points.slice(0, count);
+      }
+      // change size
       if (points.length > count) {
         size -= jump;
         jump /= 2;
@@ -180,43 +192,12 @@ class QuadTree {
         size += jump;
         // don't halve jump when enlarging the query so we don't limit max size
       }
-
+      // query again
       range = new Circle(point.x, point.y, size);
       points = this.query(range);
     }
     return points;
   }
-=======
-  }
-
-  closest(point, count) {
-    if (!this.divided && this.points.length === 0) {
-      return [];
-    }
-    if (typeof count === "undefined") {
-      count = 1;
-    }
-    // Start with a circle 1/4 the size of the boundary
-    // 1/2 the size would be purer, but most final queries are smaller than that
-    let size = Math.max(this.boundary.w, this.boundary.h) / 4;
-    let jump = size / 2; // what we change the size by
-    let range = new Circle(point.x, point.y, size);
-    let points = this.query(range);
-    while (points.length !== count) {
-      if (points.length > count) {
-        size -= jump;
-        jump /= 2;
-      } else {
-        size += jump;
-        // don't halve jump when enlarging the query so we don't limit max size
-      }
-
-      range = new Circle(point.x, point.y, size);
-      points = this.query(range);
-    }
-    return points;
-  }
->>>>>>> Stashed changes
 
 }
 

--- a/quadtree.js
+++ b/quadtree.js
@@ -194,7 +194,7 @@ class QuadTree {
       } else if (limit-- <= 0) {
         return points.slice(0, count); // Slice to return correct count (breaks ties)
       } else {
-        radius /= 1.5;
+        radius /= 3;
       }
     }
   }

--- a/quadtree.js
+++ b/quadtree.js
@@ -161,7 +161,7 @@ class QuadTree {
     return found;
   }
 
-  closest(point, count) {
+  closest(point, count, startingSize) {
     if (typeof count === "undefined") {
       count = 1;
     }
@@ -188,7 +188,7 @@ class QuadTree {
       const range = new Circle(point.x, point.y, radius);
       const points = this.query(range);
       if (points.length > 0 && limit-- <= 0) {
-        return points.slice(0, count); 
+        return points.slice(0, count);
       }
       if (points.length === count) {
         return points; // Return when we hit the right size

--- a/quadtree.js
+++ b/quadtree.js
@@ -182,6 +182,7 @@ class QuadTree {
     }
     return points;
   }
+
 }
 
 ((module ? module.exports = { Point, Rectangle, QuadTree, Circle } : 0));

--- a/quadtree.js
+++ b/quadtree.js
@@ -165,6 +165,9 @@ class QuadTree {
     if (typeof count === "undefined") {
       count = 1;
     }
+    if (typeof startingSize === "undefined") {
+      startingSize = 1;
+    }
 
     if (!this.divided) {
       // Empty
@@ -179,7 +182,7 @@ class QuadTree {
 
     // optimized, expanding binary search
     // start with a small circle, rapidly expand, slowly shrink
-    let radius = 1;
+    let radius = startingSize;
     let limit = 16;
     while (true) {
       const range = new Circle(point.x, point.y, radius);

--- a/quadtree.js
+++ b/quadtree.js
@@ -187,13 +187,12 @@ class QuadTree {
     while (true) {
       const range = new Circle(point.x, point.y, radius);
       const points = this.query(range);
-      if (points.length > 0 && limit-- <= 0) {
-        return points.slice(0, count);
-      }
       if (points.length === count) {
         return points; // Return when we hit the right size
       } else if (points.length < count) {
         radius *= 2;
+      } else if (limit-- <= 0) {
+        return points.slice(0, count); // Slice to return correct count (breaks ties)
       } else {
         radius /= 1.5;
       }

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -305,4 +305,48 @@ describe('QuadTree', () => {
       });
     });
   });
+  describe('closest', () => {
+    let quadtree;
+    let points;
+    beforeEach(() => {
+      quadtree = new QuadTree(new Rectangle(0, 0, 100, 100), 4);
+      points = [
+        new Point(20, 0),
+        new Point(40, 0),
+        new Point(60, 0),
+        new Point(80, 0)
+      ];
+      points.forEach(point => quadtree.insert(point));
+    });
+    it('returns empty array when quadtree is empty', () => {
+      quadtree = new QuadTree(new Rectangle(0, 0, 100, 100), 4);
+      found = quadtree.closest(new Point(0, 0), 1);
+      expect(found).to.have.length(0);
+    });
+    it('returns closest item', () => {
+      found = quadtree.closest(new Point(0, 0), 1);
+      expect(found).to.contain(points[0]);
+    });
+    it('returns correct number of items (one)', () => {
+      found = quadtree.closest(new Point(0, 0), 1);
+      expect(found).to.have.length(1);
+    });
+    it('returns correct number of items (many)', () => {
+      found = quadtree.closest(new Point(0, 0), 3);
+      expect(found).to.have.length(3);
+    });
+    it('returns all items when number requested exceeds QuadTree contentss', () => {
+      found = quadtree.closest(new Point(0, 0), 10);
+      expect(found).to.have.length(4);
+    });
+    it('returns correct number of items when tie occurs', () => {
+      found = quadtree.closest(new Point(30, 0), 1);
+      expect(found).to.have.length(1);
+    });
+    it('returns correct number of items when far away', () => {
+      found = quadtree.closest(new Point(-30000, 0), 1);
+      expect(found).to.have.length(1);
+      expect(found).to.contain(points[0]);
+    });
+  });
 });

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -305,7 +305,6 @@ describe('QuadTree', () => {
       });
     });
   });
-
   describe('closest', () => {
     let quadtree;
     let points;
@@ -350,6 +349,7 @@ describe('QuadTree', () => {
       found = quadtree.closest(new Point(0, 0), 10);
       expect(found).to.have.length(4);
     });
+  });
   describe('size', () => {
     let quadtree;
     beforeEach(() => {

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -335,10 +335,6 @@ describe('QuadTree', () => {
       found = quadtree.closest(new Point(0, 0), 3);
       expect(found).to.have.length(3);
     });
-    it.skip('returns all items when number requested exceeds QuadTree contentss', () => {
-      found = quadtree.closest(new Point(0, 0), 10);
-      expect(found).to.have.length(4);
-    });
     it('returns correct number of items when tie occurs', () => {
       found = quadtree.closest(new Point(30, 0), 1);
       expect(found).to.have.length(1);
@@ -347,6 +343,11 @@ describe('QuadTree', () => {
       found = quadtree.closest(new Point(-30000, 0), 1);
       expect(found).to.have.length(1);
       expect(found).to.contain(points[0]);
+    });
+    // no total count of items
+    it.skip('returns all items when number requested exceeds QuadTree contents', () => {
+      found = quadtree.closest(new Point(0, 0), 10);
+      expect(found).to.have.length(4);
     });
   });
 });


### PR DESCRIPTION
Finds a specified number of points closest to a given point.

Uses a sort of binary search with the radius of a Circle query. Using Rectangle may be more performant for finding a single closest point but produces inaccurate results for operations expecting multiple detected points.

- [x] Handle ties in the cases of:
   - [x] Equidistant points
   - [x] Identical points
- [x] Write tests

[For the handling of ties](https://github.com/CodingTrain/QuadTree/pull/25/files#diff-ca9c3c06805e72822546dc584c96cf26R184), I specified a limit on the number of checks and return a slice of the current query if we reach it.