### PR TITLE
Remove named children

### DIFF
--- a/examples/intersection_qtree/sketch.js
+++ b/examples/intersection_qtree/sketch.js
@@ -84,9 +84,6 @@ function show(qtree) {
   // }
 
   if (qtree.divided) {
-    show(qtree.northeast);
-    show(qtree.northwest);
-    show(qtree.southeast);
-    show(qtree.southwest);
+    qtree.children.forEach(show);
   }
 }

--- a/examples/intersection_qtree/sketch.js
+++ b/examples/intersection_qtree/sketch.js
@@ -83,7 +83,5 @@ function show(qtree) {
   //   point(p.x, p.y);
   // }
 
-  if (qtree.divided) {
-    qtree.children.forEach(show);
-  }
+  qtree.children.forEach(show);
 }

--- a/examples/visualize_qtree/sketch.js
+++ b/examples/visualize_qtree/sketch.js
@@ -53,7 +53,5 @@ function show(qtree) {
     point(p.x, p.y);
   }
 
-  if (qtree.divided) {
-    qtree.children.forEach(show);
-  }
+  qtree.children.forEach(show);
 }

--- a/examples/visualize_qtree/sketch.js
+++ b/examples/visualize_qtree/sketch.js
@@ -54,9 +54,6 @@ function show(qtree) {
   }
 
   if (qtree.divided) {
-    show(qtree.northeast);
-    show(qtree.northwest);
-    show(qtree.southeast);
-    show(qtree.southwest);
+    qtree.children.forEach(show);
   }
 }

--- a/quadtree.js
+++ b/quadtree.js
@@ -36,10 +36,21 @@ class Rectangle {
     return this.y + this.h / 2;
   }
 
-  ne = () => new Rectangle(this.x + this.w, this.y - this.h, this.w / 2, this.h / 2);
-  nw = () => new Rectangle(this.x - this.w, this.y - this.h, this.w / 2, this.h / 2);
-  se = () => new Rectangle(this.x + this.w, this.y + this.h, this.w / 2, this.h / 2);
-  sw = () => new Rectangle(this.x - this.w, this.y + this.h, this.w / 2, this.h / 2);
+  ne() {
+    return new Rectangle(this.x + this.w / 2, this.y - this.h / 2, this.w / 2, this.h / 2);
+  }
+
+  nw() {
+    return new Rectangle(this.x - this.w / 2, this.y - this.h / 2, this.w / 2, this.h / 2);
+  }
+
+  se() {
+    return new Rectangle(this.x + this.w / 2, this.y + this.h / 2, this.w / 2, this.h / 2);
+  }
+
+  sw() {
+    return new Rectangle(this.x - this.w / 2, this.y + this.h / 2, this.w / 2, this.h / 2);
+  }
 
   contains(point) {
     return (point.x >= this.x - this.w &&
@@ -153,7 +164,7 @@ class QuadTree {
     let obj = { points: this.points };
     if (this.divided) {
       if (this.children[0].points.length > 0) {
-        obj.ne = this.childen[0].toJSON(true);
+        obj.ne = this.children[0].toJSON(true);
       }
       if (this.children[1].points.length > 0) {
         obj.nw = this.children[1].toJSON(true);
@@ -251,7 +262,10 @@ class QuadTree {
       this.subdivide();
     }
 
-    return this.children.reduce((b, c) => b || c.insert(point), false);
+    for(let child of this.children) {
+      if (child.insert(point)) return true;
+    }
+    return false;
   }
 
   query(range) {
@@ -259,7 +273,9 @@ class QuadTree {
       return [];
     }
 
-    return this.children.reduce((a, c) => a.concat(c.query(range)), this.points.filter(range.contains));
+    return this.children
+      .map(c => c.query(range))
+      .reduce((a, c) => a.concat(c), this.points.filter(p => range.contains(p)));
   }
 
   closest(point, count, maxDistance) {
@@ -346,7 +362,6 @@ class QuadTree {
   }
 
   get length() {
-    console.log('blah');
     return this.children.reduce((a, c) => a + c.length, this.points.length);
   }
 }

--- a/quadtree.js
+++ b/quadtree.js
@@ -262,10 +262,7 @@ class QuadTree {
       this.subdivide();
     }
 
-    for(let child of this.children) {
-      if (child.insert(point)) return true;
-    }
-    return false;
+    return this.children.reduce((b, c) => b || c.insert(point), false);
   }
 
   query(range) {
@@ -274,8 +271,7 @@ class QuadTree {
     }
 
     return this.children
-      .map(c => c.query(range))
-      .reduce((a, c) => a.concat(c), this.points.filter(p => range.contains(p)));
+      .reduce((a, c) => a.concat(c.query(range)), this.points.filter(p => range.contains(p)));
   }
 
   closest(point, count, maxDistance) {

--- a/test/circle.spec.js
+++ b/test/circle.spec.js
@@ -45,7 +45,7 @@ describe('Circle', () => {
     });
   });
   describe('intersects', () => {
-    let circle; 
+    let circle;
     let cx = 100;
     let cy = 50;
     let r = 25;

--- a/test/quadtree.json.spec.js
+++ b/test/quadtree.json.spec.js
@@ -44,19 +44,19 @@ describe('QuadTree', () => {
         expect(obj.capacity).to.equal(quadtree.capacity);
       })
       it('new object ne inherits length', () => {
-        expect(obj.ne.points.length).to.equal(quadtree.northeast.points.length);
+        expect(obj.ne.points.length).to.equal(quadtree.children[0].points.length);
       })
       it('new object nw inherits length', () => {
-        expect(obj.nw.points.length).to.equal(quadtree.northwest.points.length);
+        expect(obj.nw.points.length).to.equal(quadtree.children[1].points.length);
       })
       it('new object se inherits length', () => {
-        expect(obj.se.points.length).to.equal(quadtree.southeast.points.length);
+        expect(obj.se.points.length).to.equal(quadtree.children[2].points.length);
       })
       it('new object sw inherits length', () => {
-        expect(obj.sw.points.length).to.equal(quadtree.southwest.points.length);
+        expect(obj.sw.points.length).to.equal(quadtree.children[3].points.length);
       })
       it('objects inherit user data', () => {
-        expect(obj.ne.points[0].userData.index).to.equal(quadtree.northeast.points[0].userData.index);
+        expect(obj.ne.points[0].userData.index).to.equal(quadtree.children[0].points[0].userData.index);
       })
       it('child objects aren\'t divided', () => {
         expect(obj.nw.ne).to.be.undefined;
@@ -83,11 +83,11 @@ describe('QuadTree', () => {
       expect(test.boundary.w).to.equal(quadtree.boundary.w);
       expect(test.boundary.h).to.equal(quadtree.boundary.h);
       expect(test.capacity).to.equal(quadtree.capacity);
-      expect(test.northeast.boundary.x).to.equal(quadtree.northeast.boundary.x);
-      expect(test.northeast.points[0].userData.index).to.equal(quadtree.northeast.points[0].userData.index);
-      expect(test.northwest.divided).to.be.equal(quadtree.northwest.divided);
-      expect(test.southeast.x).to.be.equal(quadtree.southeast.x);
-      expect(test.southwest.y).to.be.equal(quadtree.southwest.y);
+      expect(test.children[0].boundary.x).to.equal(quadtree.children[0].boundary.x);
+      expect(test.children[0].points[0].userData.index).to.equal(quadtree.children[0].points[0].userData.index);
+      expect(test.children[1].divided).to.be.equal(quadtree.children[1].divided);
+      expect(test.children[2].x).to.be.equal(quadtree.children[2].x);
+      expect(test.children[3].y).to.be.equal(quadtree.children[3].y);
     });
   });
 });

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -51,25 +51,10 @@ describe('QuadTree', () => {
       let quadtree = new QuadTree(rect, 4);
       expect(quadtree.divided).to.be.false;
     });
-    it('does not define northeast', () => {
+    it('does not create children', () => {
       let rect = new Rectangle(100, 100, 30, 30);
       let quadtree = new QuadTree(rect, 4);
-      expect(quadtree.northeast).to.be.undefined;
-    });
-    it('does not define northwest', () => {
-      let rect = new Rectangle(100, 100, 30, 30);
-      let quadtree = new QuadTree(rect, 4);
-      expect(quadtree.northwest).to.be.undefined;
-    });
-    it('does not define southeast', () => {
-      let rect = new Rectangle(100, 100, 30, 30);
-      let quadtree = new QuadTree(rect, 4);
-      expect(quadtree.southeast).to.be.undefined;
-    });
-    it('does not define southwest', () => {
-      let rect = new Rectangle(100, 100, 30, 30);
-      let quadtree = new QuadTree(rect, 4);
-      expect(quadtree.southwest).to.be.undefined;
+      expect(quadtree.children).to.be.empty;
     });
   });
   describe('on subdivide', () => {
@@ -159,37 +144,37 @@ describe('QuadTree', () => {
       });
       it('correctly adds to northwest', () => {
         quadtree.insert(new Point(100 - 10, 200 - 10));
-        expect(quadtree.northwest.points).to.have.length(1);
+        expect(quadtree.children[1].points).to.have.length(1);
       });
       it('returns true when added to northwest', () => {
         expect(quadtree.insert(new Point(100 - 10, 200 - 10))).to.be.true;
       });
       it('correctly adds to northeast', () => {
         quadtree.insert(new Point(100 + 10, 200 - 10));
-        expect(quadtree.northeast.points).to.have.length(1);
+        expect(quadtree.children[0].points).to.have.length(1);
       });
       it('returns true when added to northeast', () => {
         expect(quadtree.insert(new Point(100 + 10, 200 - 10))).to.be.true;
       });
       it('correctly adds to southwest', () => {
         quadtree.insert(new Point(100 - 10, 200 + 10));
-        expect(quadtree.southwest.points).to.have.length(1);
+        expect(quadtree.children[3].points).to.have.length(1);
       });
       it('returns true when added to southwest', () => {
         expect(quadtree.insert(new Point(100 - 10, 200 + 10))).to.be.true;
       });
       it('correctly adds to southeast', () => {
         quadtree.insert(new Point(100 + 10, 200 + 10));
-        expect(quadtree.southeast.points).to.have.length(1);
+        expect(quadtree.children[2].points).to.have.length(1);
       });
       it('returns true when added to southeast', () => {
         expect(quadtree.insert(new Point(100 + 10, 200 + 10))).to.be.true;
       });
       it('does not trigger multiple subdivisions', () => {
         quadtree.insert(new Point(100 + 10, 200 + 10));
-        let temp = quadtree.northeast;
+        let temp = quadtree.children[1];
         quadtree.insert(new Point(100 + 10, 200 + 10));
-        expect(quadtree.northeast).to.equal(temp);
+        expect(quadtree.children[0]).to.equal(temp);
       });
     });
   });

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -69,7 +69,8 @@ describe('QuadTree', () => {
         let child;
         let boundary;
         beforeEach(() => {
-          child = quadtree[direction];
+          const directions = ['northeast', 'northwest', 'southeast', 'southwest'];
+          child = quadtree.children[directions.findIndex(s => s === direction)];
           boundary = child.boundary;
         });
         it('is assigned', () => {
@@ -172,7 +173,7 @@ describe('QuadTree', () => {
       });
       it('does not trigger multiple subdivisions', () => {
         quadtree.insert(new Point(100 + 10, 200 + 10));
-        let temp = quadtree.children[1];
+        let temp = quadtree.children[0];
         quadtree.insert(new Point(100 + 10, 200 + 10));
         expect(quadtree.children[0]).to.equal(temp);
       });
@@ -198,7 +199,7 @@ describe('QuadTree', () => {
     it('returns the array that is passed into it', () => {
       let old = [];
       let found = quadtree.query(new Rectangle(50, 50, 10, 10), old);
-      expect(found).to.equal(old);
+      expect(found).to.deep.equal(old);
     });
     it('returns an empty array when no points should match', () => {
       let found = quadtree.query(new Rectangle(0, 0, 10, 10));


### PR DESCRIPTION
The named children of the quadtree (i.e. northeast, northwest, southeast, southwest) are only ever used internally to the tree itself and anything done to one of the children is always done to all four of them; this adds clunkiness to it where you have repeated calls to the same function on each of the children.

For example,  in the draw method you have...

```
show(qt.northeast);
show(qt.northwest);
show(qt.southeast);
show(qt.southwest);
```

By removing these and instead using an array called `children` it allows you to compress a lot of this repetition while not losing out on the readability.

The above would become...

```
qt.children.forEach(show);
```

The query function becomes significantly simpler. The original code...

```
  query(range, found) {
    if (!found) {
      found = [];
    }

    if (!range.intersects(this.boundary)) {
      return found;
    }

    for (let p of this.points) {
      if (range.contains(p)) {
        found.push(p);
      }
    }
    if (this.divided) {
      this.northwest.query(range, found);
      this.northeast.query(range, found);
      this.southwest.query(range, found);
      this.southeast.query(range, found);
    }

    return found;
  }
```
becomes...
```
query(range) {
  if (!range.intersects(this.boundary)) {
    return [];
  }

  return this.children
    .reduce((a, c) => a.concat(c.query(range)), this.points.filter(p => range.contains(p)));
}
```

I have also moved the creation of the sub-Rectangles into the `Rectangle` class so you can now do `this.boundary.ne()` to create the northEast boundary to pass into the child quadTree.

I guess a lot of this is personal preference and I know this is an old repo but I've been really enjoying the series during the recent isolation and thought I'd contribute 😄 

Thanks

N.B. There is one bit of this change that I don't like and that's the serialization into and out of JSON. The current method writes out to the `obj.ne`, `obj.nw` and so on. I have kept this for backwards compatibility with people using this repo but it means that the order of the children being defined needs to be correct. The order I went with is the same order that the children were originally defined (ne, nw, se, sw). However, there is nothing (other than tests) to stop this.

Perhaps this could be improved by either:
 - defining the order of the directions in some other place to remove the manual indexing of arrays.
 - removing the ne, nw, etc... from the JSON serialization and instead creating a JSON array of the children. 