### PR TITLE
When dividing the rectangle, now its child-points will be moved to the new child-rectangles

### DIFF
--- a/quadtree.js
+++ b/quadtree.js
@@ -234,7 +234,7 @@ class QuadTree {
     this.southeast = new QuadTree(se, this.capacity);
     let sw = new Rectangle(x - w, y + h, w, h);
     this.southwest = new QuadTree(sw, this.capacity);
-
+    
     this.divided = true;
   }
 
@@ -243,13 +243,16 @@ class QuadTree {
       return false;
     }
 
-    if (this.points.length < this.capacity) {
-      this.points.push(point);
-      return true;
-    }
-
     if (!this.divided) {
+      if (this.points.length < this.capacity) {
+        this.points.push(point);
+        return true;
+      }
+      
       this.subdivide();
+      
+      let point;
+      while (point = this.points.shift()) this.insert(point);
     }
 
     return (this.northeast.insert(point) || this.northwest.insert(point) ||
@@ -265,16 +268,17 @@ class QuadTree {
       return found;
     }
 
-    for (let p of this.points) {
-      if (range.contains(p)) {
-        found.push(p);
-      }
-    }
     if (this.divided) {
       this.northwest.query(range, found);
       this.northeast.query(range, found);
       this.southwest.query(range, found);
       this.southeast.query(range, found);
+    } else {
+      for (let p of this.points) {
+        if (range.contains(p)) {
+          found.push(p);
+        }
+      }
     }
 
     return found;

--- a/quadtree.js
+++ b/quadtree.js
@@ -251,8 +251,8 @@ class QuadTree {
       
       this.subdivide();
       
-      let point;
-      while (point = this.points.shift()) this.insert(point);
+      let p;
+      while (p = this.points.shift()) this.insert(p);
     }
 
     return (this.northeast.insert(point) || this.northwest.insert(point) ||


### PR DESCRIPTION
> I may be wrong and would like to hear objective criticism about this pull request

# Why?

### Reason number 1

Imagine a QuadTree with a capacity of 1.
When you insert a point, everything's fine, right?
![image](https://user-images.githubusercontent.com/65278392/109385356-30c55180-7904-11eb-863e-ca72ca1b7388.png)
But if you add a second point, the tree will probably look like this:
![image](https://user-images.githubusercontent.com/65278392/109385475-2c4d6880-7905-11eb-84e9-0af26da17c17.png)
Because the red point is counted as a child of the top-right rectangle, while the black point is still counted as a child of the big main rectangle. So that's you would visually see these two points in the same rectangle. Remember that the capacity of this tree is 1. For me, it looks pretty wrong.

### Reason number 2

Now in the query() function, the loop runs only on the smallest squares (that are not divided), I believe this increases the searching performance.