### PR TITLE
Fix width and height usage

### DIFF
--- a/quadtree.js
+++ b/quadtree.js
@@ -38,16 +38,16 @@ class Rectangle {
 
   contains(point) {
     return (
-      this.x - this.w <= point.x && point.x < this.x + this.w &&
-      this.y - this.h <= point.y && point.y < this.y + this.h
+      this.left <= point.x && point.x < this.right &&
+      this.top <= point.y && point.y < this.bottom
     );
   }
 
 
   intersects(range) {
     return !(
-      this.x + this.w < range.x - range.w || range.x + range.w < this.x - this.w ||
-      this.y + this.h < range.y - range.h || range.y + range.h < this.y - this.h
+      this.right < range.left || range.right < this.left ||
+      this.bottom < range.top || range.bottom < this.top
     );
   }
 }

--- a/quadtree.js
+++ b/quadtree.js
@@ -88,8 +88,8 @@ class Circle {
     // radius of the circle
     let r = this.r;
 
-    let w = range.w;
-    let h = range.h;
+    let w = range.w / 2;
+    let h = range.h / 2;
 
     let edges = Math.pow((xDist - w), 2) + Math.pow((yDist - h), 2);
 

--- a/quadtree.js
+++ b/quadtree.js
@@ -45,8 +45,8 @@ class Rectangle {
 
   intersects(range) {
     return !(
-      this.x + this.w < range.x - range.w || range.x + range.w < this.x - this.w ||
-      this.y + this.h < range.y - range.h || range.y + range.h < this.y - this.h
+      this.right < range.left || range.right < this.left ||
+      this.bottom < range.top || range.bottom < this.top
     );
   }
 

--- a/quadtree.js
+++ b/quadtree.js
@@ -18,22 +18,10 @@ class Rectangle {
     this.y = y;
     this.w = w;
     this.h = h;
-  }
-
-  get left() {
-    return this.x - this.w / 2;
-  }
-
-  get right() {
-    return this.x + this.w / 2;
-  }
-
-  get top() {
-    return this.y - this.h / 2;
-  }
-
-  get bottom() {
-    return this.y + this.h / 2;
+    this.left = x - w / 2;
+    this.right = x + w / 2;
+    this.top = y - h / 2;
+    this.bottom = y + h / 2;
   }
 
   contains(point) {

--- a/quadtree.js
+++ b/quadtree.js
@@ -43,12 +43,24 @@ class Rectangle {
     );
   }
 
-
   intersects(range) {
     return !(
       this.x + this.w < range.x - range.w || range.x + range.w < this.x - this.w ||
       this.y + this.h < range.y - range.h || range.y + range.h < this.y - this.h
     );
+  }
+
+  subdivide(quadrant) {
+    switch (quadrant) {
+      case 'ne':
+        return new Rectangle(this.x + this.w / 4, this.y - this.h / 4, this.w / 2, this.h / 2);
+      case 'nw':
+        return new Rectangle(this.x - this.w / 4, this.y - this.h / 4, this.w / 2, this.h / 2);
+      case 'se':
+        return new Rectangle(this.x + this.w / 4, this.y + this.h / 4, this.w / 2, this.h / 2);
+      case 'sw':
+        return new Rectangle(this.x - this.w / 4, this.y + this.h / 4, this.w / 2, this.h / 2);
+    }
   }
 }
 
@@ -193,24 +205,24 @@ class QuadTree {
       let h = qt.boundary.h / 2;
 
       if ("ne" in obj) {
-        qt.northeast = QuadTree.fromJSON(obj.ne, x + w, y - h, w, h, capacity);
+        qt.northeast = QuadTree.fromJSON(obj.ne, x + w/2, y - h/2, w, h, capacity);
       } else {
-        qt.northeast = new QuadTree(new Rectangle(x + w, y - h, w, h), capacity);
+        qt.northeast = new QuadTree(qt.boundary.subdivide('ne'), capacity);
       }
       if ("nw" in obj) {
-        qt.northwest = QuadTree.fromJSON(obj.nw, x - w, y - h, w, h, capacity);
+        qt.northwest = QuadTree.fromJSON(obj.nw, x - w/2, y - h/2, w, h, capacity);
       } else {
-        qt.northwest = new QuadTree(new Rectangle(x - w, y - h, w, h), capacity);
+        qt.northwest = new QuadTree(qt.boundary.subdivide('nw'), capacity);
       }
       if ("se" in obj) {
-        qt.southeast = QuadTree.fromJSON(obj.se, x + w, y + h, w, h, capacity);
+        qt.southeast = QuadTree.fromJSON(obj.se, x + w/2, y + h/2, w, h, capacity);
       } else {
-        qt.southeast = new QuadTree(new Rectangle(x + w, y + h, w, h), capacity);
+        qt.southeast = new QuadTree(qt.boundary.subdivide('se'), capacity);
       }
       if ("sw" in obj) {
-        qt.southwest = QuadTree.fromJSON(obj.sw, x - w, y + h, w, h, capacity);
+        qt.southwest = QuadTree.fromJSON(obj.sw, x - w/2, y + h/2, w, h, capacity);
       } else {
-        qt.southwest = new QuadTree(new Rectangle(x - w, y + h, w, h), capacity);
+        qt.southwest = new QuadTree(qt.boundary.subdivide('sw'), capacity);
       }
 
       qt.divided = true;
@@ -219,19 +231,10 @@ class QuadTree {
   }
 
   subdivide() {
-    let x = this.boundary.x;
-    let y = this.boundary.y;
-    let w = this.boundary.w / 2;
-    let h = this.boundary.h / 2;
-
-    let ne = new Rectangle(x + w, y - h, w, h);
-    this.northeast = new QuadTree(ne, this.capacity);
-    let nw = new Rectangle(x - w, y - h, w, h);
-    this.northwest = new QuadTree(nw, this.capacity);
-    let se = new Rectangle(x + w, y + h, w, h);
-    this.southeast = new QuadTree(se, this.capacity);
-    let sw = new Rectangle(x - w, y + h, w, h);
-    this.southwest = new QuadTree(sw, this.capacity);
+    this.northeast = new QuadTree(this.boundary.subdivide('ne'), this.capacity);
+    this.northwest = new QuadTree(this.boundary.subdivide('nw'), this.capacity);
+    this.southeast = new QuadTree(this.boundary.subdivide('se'), this.capacity);
+    this.southwest = new QuadTree(this.boundary.subdivide('sw'), this.capacity);
 
     this.divided = true;
   }
@@ -250,8 +253,12 @@ class QuadTree {
       this.subdivide();
     }
 
-    return (this.northeast.insert(point) || this.northwest.insert(point) ||
-      this.southeast.insert(point) || this.southwest.insert(point));
+    return (
+      this.northeast.insert(point) ||
+      this.northwest.insert(point) ||
+      this.southeast.insert(point) ||
+      this.southwest.insert(point)
+    );
   }
 
   query(range, found) {
@@ -297,7 +304,7 @@ class QuadTree {
     if (typeof maxDistance === "undefined") {
       // A circle as big as the QuadTree's boundary
       const outerReach = Math.sqrt(
-        Math.pow(this.boundary.w, 2) + Math.pow(this.boundary.h, 2)
+        Math.pow(this.boundary.w / 2, 2) + Math.pow(this.boundary.h / 2, 2)
       );
       // Distance of query point from center
       const pointDistance = Math.sqrt(

--- a/quadtree.js
+++ b/quadtree.js
@@ -37,21 +37,19 @@ class Rectangle {
   }
 
   contains(point) {
-    return (point.x >= this.x - this.w &&
-      point.x <= this.x + this.w &&
-      point.y >= this.y - this.h &&
-      point.y <= this.y + this.h);
+    return (
+      this.x - this.w <= point.x && point.x < this.x + this.w &&
+      this.y - this.h <= point.y && point.y < this.y + this.h
+    );
   }
 
 
   intersects(range) {
-    return !(range.x - range.w > this.x + this.w ||
-      range.x + range.w < this.x - this.w ||
-      range.y - range.h > this.y + this.h ||
-      range.y + range.h < this.y - this.h);
+    return !(
+      this.x + this.w < range.x - range.w || range.x + range.w < this.x - this.w ||
+      this.y + this.h < range.y - range.h || range.y + range.h < this.y - this.h
+    );
   }
-
-
 }
 
 // circle class for a circle shaped query

--- a/quadtree.js
+++ b/quadtree.js
@@ -24,18 +24,7 @@ class Rectangle {
     this.bottom = y + h / 2;
   }
 
-  // function used to determine if a point should be added into this region
-  // if it lies on the right or bottom edge then it should not be in this region
   contains(point) {
-    return (
-      this.left <= point.x && point.x < this.right &&
-      this.top <= point.y && point.y < this.bottom
-    );
-  }
-
-  // function used to determine if a point is in a query region
-  // if the point is on any edge then it should be counted for the query
-  queryContains(point) {
     return (
       this.left <= point.x && point.x <= this.right &&
       this.top <= point.y && point.y <= this.bottom
@@ -72,7 +61,7 @@ class Circle {
     this.rSquared = this.r * this.r;
   }
 
-  queryContains(point) {
+  contains(point) {
     // check if the point is in the circle by checking if the euclidean distance of
     // the point and the center of the circle if smaller or equal to the radius of
     // the circle
@@ -270,7 +259,7 @@ class QuadTree {
     }
 
     for (let p of this.points) {
-      if (range.queryContains(p)) {
+      if (range.contains(p)) {
         found.push(p);
       }
     }

--- a/quadtree.js
+++ b/quadtree.js
@@ -24,10 +24,21 @@ class Rectangle {
     this.bottom = y + h / 2;
   }
 
+  // function used to determine if a point should be added into this region
+  // if it lies on the right or bottom edge then it should not be in this region
   contains(point) {
     return (
       this.left <= point.x && point.x < this.right &&
       this.top <= point.y && point.y < this.bottom
+    );
+  }
+
+  // function used to determine if a point is in a query region
+  // if the point is on any edge then it should be counted for the query
+  queryContains(point) {
+    return (
+      this.left <= point.x && point.x <= this.right &&
+      this.top <= point.y && point.y <= this.bottom
     );
   }
 
@@ -61,7 +72,7 @@ class Circle {
     this.rSquared = this.r * this.r;
   }
 
-  contains(point) {
+  queryContains(point) {
     // check if the point is in the circle by checking if the euclidean distance of
     // the point and the center of the circle if smaller or equal to the radius of
     // the circle
@@ -259,7 +270,7 @@ class QuadTree {
     }
 
     for (let p of this.points) {
-      if (range.contains(p)) {
+      if (range.queryContains(p)) {
         found.push(p);
       }
     }

--- a/quadtree.js
+++ b/quadtree.js
@@ -46,8 +46,8 @@ class Rectangle {
 
   intersects(range) {
     return !(
-      this.right < range.left || range.right < this.left ||
-      this.bottom < range.top || range.bottom < this.top
+      this.x + this.w < range.x - range.w || range.x + range.w < this.x - this.w ||
+      this.y + this.h < range.y - range.h || range.y + range.h < this.y - this.h
     );
   }
 }

--- a/test/circle.spec.js
+++ b/test/circle.spec.js
@@ -40,12 +40,12 @@ describe('Circle', () => {
       { desc: 'outside right', x: cx + r + 1, y: cy, in: false }
     ].forEach(element => {
       it(`returns ${element.in} for ${element.desc} (${element.x}, ${element.y})`, () => {
-        expect(circle.contains(element)).to.equal(element.in);
+        expect(circle.queryContains(element)).to.equal(element.in);
       });
     });
   });
   describe('intersects', () => {
-    let circle; 
+    let circle;
     let cx = 100;
     let cy = 50;
     let r = 25;

--- a/test/circle.spec.js
+++ b/test/circle.spec.js
@@ -40,7 +40,7 @@ describe('Circle', () => {
       { desc: 'outside right', x: cx + r + 1, y: cy, in: false }
     ].forEach(element => {
       it(`returns ${element.in} for ${element.desc} (${element.x}, ${element.y})`, () => {
-        expect(circle.queryContains(element)).to.equal(element.in);
+        expect(circle.contains(element)).to.equal(element.in);
       });
     });
   });

--- a/test/quadtree.json.spec.js
+++ b/test/quadtree.json.spec.js
@@ -7,14 +7,14 @@ describe('QuadTree', () => {
     beforeEach(() => {
       quadtree = new QuadTree(new Rectangle(0, 0, 40, 40), 2);
       points = [
-        new Point(-20, 20, { index: 0 }),
-        new Point(-20, -20, { index: 1 }),
-        new Point(20, 20, { index: 2 }),
-        new Point(20, -20, { index: 3 }),
-        new Point(-25, 25, { index: 4 }),
-        new Point(-25, -25, { index: 5 }),
-        new Point(25, 25, { index: 6 }),
-        new Point(25, -25, { index: 7 })
+        new Point(-10, 10, { index: 0 }),
+        new Point(-10, -10, { index: 1 }),
+        new Point(10, 10, { index: 2 }),
+        new Point(10, -10, { index: 3 }),
+        new Point(-15, 15, { index: 4 }),
+        new Point(-15, -15, { index: 5 }),
+        new Point(15, 15, { index: 6 }),
+        new Point(15, -15, { index: 7 })
       ];
       points.forEach(point => quadtree.insert(point));
     });

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -137,6 +137,13 @@ describe('QuadTree', () => {
       quadtree.insert(new Point(100, 226));
       expect(quadtree.points).to.have.length(0);
     });
+    it('does add to points array when point is on the boundary', () => {
+      quadtree.insert(new Point(90, 200));
+      quadtree.insert(new Point(110, 200));
+      quadtree.insert(new Point(100, 175));
+      quadtree.insert(new Point(100, 225));
+      expect(quadtree.points).to.have.length(4);
+    });
     it('returns true when capacity not hit and boundary does contain point', () => {
       expect(quadtree.insert(new Point(100,200))).to.be.true;
     });

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -231,6 +231,10 @@ describe('QuadTree', () => {
       let found = quadtree.query(new Rectangle(25, 25, 10, 10));
       expect(found).to.contain(points[3]);
     });
+    it('returns an item on the right edge of the query region', () => {
+      let found = quadtree.query(new Rectangle(20, 20, 10, 10));
+      expect(found).to.contain(points[3]);
+    });
     describe('when a subdivision occurs', () => {
       beforeEach(() => {
         points.push(new Point(-26, -26));

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -232,7 +232,11 @@ describe('QuadTree', () => {
       expect(found).to.contain(points[3]);
     });
     it('returns an item on the right edge of the query region', () => {
-      let found = quadtree.query(new Rectangle(20, 20, 10, 10));
+      let found = quadtree.query(new Rectangle(20, 25, 10, 10));
+      expect(found).to.contain(points[3]);
+    });
+    it('returns an item on the bottom edge of the query region', () => {
+      let found = quadtree.query(new Rectangle(25, 20, 10, 10));
       expect(found).to.contain(points[3]);
     });
     describe('when a subdivision occurs', () => {

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -131,7 +131,10 @@ describe('QuadTree', () => {
       expect(quadtree.insert(new Point(10, 20))).to.be.false;
     });
     it('does not add to points array when boundary does not contain point', () => {
-      quadtree.insert(new Point(10, 20));
+      quadtree.insert(new Point(89, 200));
+      quadtree.insert(new Point(111, 200));
+      quadtree.insert(new Point(100, 174));
+      quadtree.insert(new Point(100, 226));
       expect(quadtree.points).to.have.length(0);
     });
     it('returns true when capacity not hit and boundary does contain point', () => {

--- a/test/quadtree.spec.js
+++ b/test/quadtree.spec.js
@@ -115,10 +115,10 @@ describe('QuadTree', () => {
     it('marks subdivided as true', () => {
       expect(quadtree.divided).to.be.true;
     });
-    childTests('northwest', cx - w / 2, cy - h / 2);
-    childTests('northeast', cx + w / 2, cy - h / 2);
-    childTests('southwest', cx - w / 2, cy + h / 2);
-    childTests('southeast', cx + w / 2, cy + h / 2);
+    childTests('northwest', cx - w / 4, cy - h / 4);
+    childTests('northeast', cx + w / 4, cy - h / 4);
+    childTests('southwest', cx - w / 4, cy + h / 4);
+    childTests('southeast', cx + w / 4, cy + h / 4);
   });
   describe('insert', () => {
     let rect;
@@ -165,11 +165,11 @@ describe('QuadTree', () => {
         expect(quadtree.insert(new Point(100 - 10, 200 - 10))).to.be.true;
       });
       it('correctly adds to northeast', () => {
-        quadtree.insert(new Point(100 + 10, 200 - 10));
+        quadtree.insert(new Point(100 + 5, 200 - 10));
         expect(quadtree.northeast.points).to.have.length(1);
       });
       it('returns true when added to northeast', () => {
-        expect(quadtree.insert(new Point(100 + 10, 200 - 10))).to.be.true;
+        expect(quadtree.insert(new Point(100 + 5, 200 - 10))).to.be.true;
       });
       it('correctly adds to southwest', () => {
         quadtree.insert(new Point(100 - 10, 200 + 10));
@@ -179,16 +179,16 @@ describe('QuadTree', () => {
         expect(quadtree.insert(new Point(100 - 10, 200 + 10))).to.be.true;
       });
       it('correctly adds to southeast', () => {
-        quadtree.insert(new Point(100 + 10, 200 + 10));
+        quadtree.insert(new Point(100 + 5, 200 + 10));
         expect(quadtree.southeast.points).to.have.length(1);
       });
       it('returns true when added to southeast', () => {
-        expect(quadtree.insert(new Point(100 + 10, 200 + 10))).to.be.true;
+        expect(quadtree.insert(new Point(100 + 5, 200 + 10))).to.be.true;
       });
       it('does not trigger multiple subdivisions', () => {
-        quadtree.insert(new Point(100 + 10, 200 + 10));
+        quadtree.insert(new Point(100 + 5, 200 + 10));
         let temp = quadtree.northeast;
-        quadtree.insert(new Point(100 + 10, 200 + 10));
+        quadtree.insert(new Point(100 + 5, 200 + 10));
         expect(quadtree.northeast).to.equal(temp);
       });
     });
@@ -280,11 +280,11 @@ describe('QuadTree', () => {
         expect(found).to.contain(points[5]);
       });
       it('returns correct number of points from multiple regions', () => {
-        let found = quadtree.query(new Rectangle(0, -25, 50, 10));
+        let found = quadtree.query(new Rectangle(0, -25, 60, 10));
         expect(found).to.have.length(4);
       });
       it('returns correct points from multiple regions', () => {
-        let found = quadtree.query(new Rectangle(0, -25, 50, 10));
+        let found = quadtree.query(new Rectangle(0, -25, 60, 10));
         expect(found).to.contain(points[0]);
         expect(found).to.contain(points[4]);
         expect(found).to.contain(points[1]);
@@ -313,8 +313,8 @@ describe('QuadTree', () => {
       points = [
         new Point(20, 0),
         new Point(40, 0),
-        new Point(60, 0),
-        new Point(80, 0)
+        new Point(-30, 0),
+        new Point(-40, 0)
       ];
       points.forEach(point => quadtree.insert(point));
     });
@@ -353,7 +353,7 @@ describe('QuadTree', () => {
     it('returns correct number of items when far away', () => {
       found = quadtree.closest(new Point(-30000, 0), 1);
       expect(found).to.have.length(1);
-      expect(found).to.contain(points[0]);
+      expect(found).to.contain(points[3]);
     });
     // Supplied maxDistance
     it('limits search to maxDistance', () => {

--- a/test/rectangle.spec.js
+++ b/test/rectangle.spec.js
@@ -1,7 +1,7 @@
 const {expect} = require('chai');
 let { Rectangle, Point } = require('../quadtree');
 
-describe('Rectangle', () => {
+describe.only('Rectangle', () => {
   describe('on construction', () => {
     it('sets x', () => {
       let rect = new Rectangle(12, 23, 40, 83);
@@ -36,10 +36,10 @@ describe('Rectangle', () => {
       let w = 25;
       let h = 30;
       rect = new Rectangle(cx, cy, w, h);;
-      left = cx - w;
-      right = cx + w;
-      top = cy - h;
-      bottom = cy + h;
+      left = rect.left;
+      right = rect.right;
+      top = rect.top;
+      bottom = rect.bottom;
     });
     it('returns true when point is in the center', () => {
       let point = new Point(cx, cy);

--- a/test/rectangle.spec.js
+++ b/test/rectangle.spec.js
@@ -109,11 +109,11 @@ describe('Rectangle', () => {
       cy = 200;
       w = 50;
       h = 25;
-      left = cx - w;
-      right = cx + w;
-      top = cy - h;
-      bottom = cy + h;
       base = new Rectangle(cx, cy, w, h);
+      left = base.left;
+      right = base.right ;
+      top = base.top;
+      bottom = base.bottom;
     });
     it('returns true when second rectangle is inside first', () => {
       let test = new Rectangle(cx, cy, w / 2, h / 2);
@@ -128,7 +128,7 @@ describe('Rectangle', () => {
       expect(base.intersects(test)).to.be.true;
     });
     it('returns true when edges line up on the left', () => {
-      let test = new Rectangle(left - 10, cy, 10, 10);
+      let test = new Rectangle(left - 10, cy, 20, 20);
       expect(base.intersects(test)).to.be.true;
     });
     it('returns false when edges do not line up on the left', () => {
@@ -136,7 +136,7 @@ describe('Rectangle', () => {
       expect(base.intersects(test)).not.to.be.true;
     });
     it('returns true when edges line up on the right', () => {
-      let test = new Rectangle(right + 10, cy, 10, 10);
+      let test = new Rectangle(right + 10, cy, 20, 20);
       expect(base.intersects(test)).to.be.true;
     });
     it('returns false when edges do not line up on the right', () => {
@@ -144,7 +144,7 @@ describe('Rectangle', () => {
       expect(base.intersects(test)).not.to.be.true;
     });
     it('returns true when edges line up on the top', () => {
-      let test = new Rectangle(cx, top - 10, 10, 10);
+      let test = new Rectangle(cx, top - 10, 20, 20);
       expect(base.intersects(test)).to.be.true;
     });
     it('returns false when edges do not line up on the top', () => {
@@ -152,7 +152,7 @@ describe('Rectangle', () => {
       expect(base.intersects(test)).not.to.be.true;
     });
     it('returns true when edges line up on the bottom', () => {
-      let test = new Rectangle(cx, bottom + 10, 10, 10);
+      let test = new Rectangle(cx, bottom + 10, 20, 20);
       expect(base.intersects(test)).to.be.true;
     });
     it('returns false when edges do not line up on the bottom', () => {

--- a/test/rectangle.spec.js
+++ b/test/rectangle.spec.js
@@ -1,7 +1,7 @@
 const {expect} = require('chai');
 let { Rectangle, Point } = require('../quadtree');
 
-describe.only('Rectangle', () => {
+describe('Rectangle', () => {
   describe('on construction', () => {
     it('sets x', () => {
       let rect = new Rectangle(12, 23, 40, 83);

--- a/test/rectangle.spec.js
+++ b/test/rectangle.spec.js
@@ -57,9 +57,9 @@ describe('Rectangle', () => {
       let point = new Point(left - 1, cy);
       expect(rect.contains(point)).not.to.be.true;
     });
-    it('returns false when point on right edge', () => {
+    it('returns true when point on right edge', () => {
       let point = new Point(right, cy);
-      expect(rect.contains(point)).to.be.false;
+      expect(rect.contains(point)).to.be.true;
     });
     it('returns true when point inside right edge', () => {
       let point = new Point(right - 1, cy);
@@ -81,9 +81,9 @@ describe('Rectangle', () => {
       let point = new Point(cx, top - 1);
       expect(rect.contains(point)).not.to.be.true;
     });
-    it('returns false when point on bottom edge', () => {
+    it('returns true when point on bottom edge', () => {
       let point = new Point(cx, bottom);
-      expect(rect.contains(point)).to.be.false;
+      expect(rect.contains(point)).to.be.true;
     });
     it('returns true when point inside bottom edge', () => {
       let point = new Point(cx, bottom - 1);

--- a/test/rectangle.spec.js
+++ b/test/rectangle.spec.js
@@ -57,9 +57,9 @@ describe('Rectangle', () => {
       let point = new Point(left - 1, cy);
       expect(rect.contains(point)).not.to.be.true;
     });
-    it('returns true when point on right edge', () => {
+    it('returns false when point on right edge', () => {
       let point = new Point(right, cy);
-      expect(rect.contains(point)).to.be.true;
+      expect(rect.contains(point)).to.be.false;
     });
     it('returns true when point inside right edge', () => {
       let point = new Point(right - 1, cy);
@@ -81,9 +81,9 @@ describe('Rectangle', () => {
       let point = new Point(cx, top - 1);
       expect(rect.contains(point)).not.to.be.true;
     });
-    it('returns true when point on bottom edge', () => {
+    it('returns false when point on bottom edge', () => {
       let point = new Point(cx, bottom);
-      expect(rect.contains(point)).to.be.true;
+      expect(rect.contains(point)).to.be.false;
     });
     it('returns true when point inside bottom edge', () => {
       let point = new Point(cx, bottom - 1);


### PR DESCRIPTION
Updating the width/height issues.

Currently width and height are used to mean one of two things...

1. The distance from the centre of a node to the edge.
2. The distance from one edge of a node to the opposite edge.

The second use is more consistent with how "width" and "height" are used as general concepts so I am opting to use this as the new single definition.

Another small fix I will apply is the comparison check to determine if a point is "in" a node. Currently, a point can belong to multiple sibling nodes (i.e. nodes on the same level). I will update so that each point can only belong to a single node.