### PR TITLE
Update k-nearest-neighbors algorithm and added example from @crhallberg

### DIFF
--- a/examples/closest_vis_qtree/index.html
+++ b/examples/closest_vis_qtree/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<title>QuadTree</title>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
+	<script src="../../quadtree.js"></script>
+	<script src="sketch.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/examples/closest_vis_qtree/sketch.js
+++ b/examples/closest_vis_qtree/sketch.js
@@ -1,0 +1,104 @@
+let qtree;
+let searchedQuads = [];
+
+function setup() {
+    createCanvas(600, 600);
+
+    rectMode(CENTER);
+
+    qtree = QuadTree.create();
+
+    for (let i = 0; i < 1000; i++) {
+        let p = new Point(
+            Math.round(Math.random() * width),
+            Math.round(Math.random() * height),
+            {
+                searched: false,
+                closest: false,
+            }
+        );
+        qtree.insert(p);
+    }
+
+    console.log(qtree);
+}
+
+function draw() {
+    background("#0e141f");
+
+    noFill();
+    stroke("#273445");
+    drawQuads(qtree);
+
+    stroke("#a56de2");
+    for (let quad of searchedQuads) {
+        rect(quad.x, quad.y, quad.w, quad.h);
+    }
+
+    noStroke();
+    qtree.forEach((p) => {
+        fill("#95a3ab");
+        if (p.userData.searched) {
+            fill("#ffa154");
+        }
+        if (p.userData.closest) {
+            fill("#68b723");
+        }
+
+        rect(p.x, p.y, 6, 6);
+    });
+}
+
+function drawQuads(tree) {
+    rect(tree.boundary.x, tree.boundary.y, tree.boundary.w, tree.boundary.h);
+    tree.children.map(drawQuads);
+}
+
+function kNearest(tree, searchPoint, maxCount = 1, maxDistance = Infinity, furthestDistance = 0, foundSoFar = 0) {
+    if (typeof searchPoint === "undefined") {
+        throw TypeError("Method 'closest' needs a point");
+    }
+
+    let found = [];
+
+    tree.points.forEach((p) => {
+        const distance = p.distanceFrom(searchPoint);
+        p.userData.searched = true;
+        if (distance > maxDistance) {
+            return;
+        } else if (foundSoFar < maxCount || distance < furthestDistance) {
+            found.push(p);
+            furthestDistance = max(distance, furthestDistance);
+            foundSoFar++;
+        }
+    });
+
+    tree.children.forEach((child) => {
+        const distance = child.boundary.distanceFrom(searchPoint);
+        if (distance > maxDistance) {
+            return;
+        } else if (foundSoFar < maxCount || distance < furthestDistance) {
+            const childPoints = kNearest(child, searchPoint, maxCount, maxDistance, furthestDistance, foundSoFar);
+            searchedQuads.push(child.boundary);
+            found = found.concat(childPoints);
+        }
+    });
+
+    return found.sort((a, b) => a.distanceFrom(searchPoint) - b.distanceFrom(searchPoint))
+        .slice(0, maxCount);
+}
+
+function mousePressed() {
+    searchedQuads = [];
+    qtree.forEach((p) => {
+        p.userData = {
+            searched: false,
+            closest: false,
+        };
+    });
+    let mp = new Point(mouseX, mouseY);
+    let closest = kNearest(qtree, mp);
+    closest.forEach((p) => {
+        p.userData.closest = true;
+    });
+}

--- a/quadtree.js
+++ b/quadtree.js
@@ -343,8 +343,7 @@ class QuadTree {
       const distance = child.boundary.distanceFrom(searchPoint);
       if (distance > maxDistance) return;
       if (foundSoFar < maxCount || distance < furthestDistance) {
-        const childPoints = child.closest(searchPoint, maxCount, maxDistance, furthestDistance, foundSoFar);
-        found = found.concat(childPoints);
+        found = found.concat(child.closest(searchPoint, maxCount, maxDistance, furthestDistance, foundSoFar));
       }
     });
 

--- a/quadtree.js
+++ b/quadtree.js
@@ -347,7 +347,7 @@ class QuadTree {
         }
       });
 
-    this.points.sort((a, b) => a.distanceFrom(searchPoint) - b.distanceFrom(searchPoint))
+    this.points
       .forEach((p) => {
         const distance = p.distanceFrom(searchPoint);
         if (distance > maxDistance) {

--- a/quadtree.js
+++ b/quadtree.js
@@ -347,7 +347,7 @@ class QuadTree {
         }
       });
 
-    this.points
+    this.points.sort((a, b) => a.distanceFrom(searchPoint) - b.distanceFrom(searchPoint))
       .forEach((p) => {
         const distance = p.distanceFrom(searchPoint);
         if (distance > maxDistance) {

--- a/test/k-nearest-neighbors.spec.js
+++ b/test/k-nearest-neighbors.spec.js
@@ -94,4 +94,18 @@ describe('K Nearest Neighbors', () => {
 
     expect(qt.closest(point, 100000).length).to.equal(100000);
   });
+  it('A million of points to test performance', () => {
+    const rect = new Rectangle(500, 500, 1000, 1000);
+    let qt = new QuadTree(rect, 100);
+
+    for(var i=0; i<1000000; ++i) {
+      const x = Math.random() * 1000;
+      const y = Math.random() * 1000;
+      qt.insert(new Point(x, y));
+    }
+
+    const point = new Point(500, 500);
+
+    expect(qt.closest(point, 10).length).to.equal(10);
+  });
 });

--- a/test/k-nearest-neighbors.spec.js
+++ b/test/k-nearest-neighbors.spec.js
@@ -94,18 +94,4 @@ describe('K Nearest Neighbors', () => {
 
     expect(qt.closest(point, 100000).length).to.equal(100000);
   });
-  it('A million of points to test performance', () => {
-    const rect = new Rectangle(500, 500, 1000, 1000);
-    let qt = new QuadTree(rect, 100);
-
-    for(var i=0; i<1000000; ++i) {
-      const x = Math.random() * 1000;
-      const y = Math.random() * 1000;
-      qt.insert(new Point(x, y));
-    }
-
-    const point = new Point(500, 500);
-
-    expect(qt.closest(point, 10).length).to.equal(10);
-  });
 });

--- a/test/k-nearest-neighbors.spec.js
+++ b/test/k-nearest-neighbors.spec.js
@@ -94,4 +94,18 @@ describe('K Nearest Neighbors', () => {
 
     expect(qt.closest(point, 100000).length).to.equal(100000);
   });
+  it('Stupid numnber of points', () => {
+    const rect = new Rectangle(500, 500, 1000, 1000);
+    let qt = new QuadTree(rect, 100);
+
+    for(var i=0; i<1000000; ++i) {
+      const x = Math.random() * 1000;
+      const y = Math.random() * 1000;
+      qt.insert(new Point(x, y));
+    }
+
+    const point = new Point(500, 500);
+
+    expect(qt.closest(point, 10).length).to.equal(10);
+  });
 });


### PR DESCRIPTION
As pointed out by @crhallberg the algorithm I had implemented was not as optimised as it could be and was searching too many points when displayed in the example he wrote.

I have now improved the algorithm and it cuts down how many quads and points are searched by a lot.

The screenshot shown here is searching for the single closest point with no distance limit...

https://user-images.githubusercontent.com/26765636/111764426-1810e180-889b-11eb-8816-e90039599f47.mov

It is still not ideal but that is due to the fact that the tree is not "balanced". Ideally, all the points of the quad tree should be contained in the leaves of the tree (i.e. the very bottom sub trees) with no points left higher up the tree. This allows the k-nearest-neighbors search to eliminate entire subsections of the quad tree just by the frame they have and only then start searching for points.

Perhaps this is something we could re-address. There are some nice PRs open that address this and could be good to merge in with some fixes.