### PR TITLE
Add deleteInRange, clear, filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.9
+      - image: circleci/node:lts
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/quadtree.js
+++ b/quadtree.js
@@ -13,11 +13,12 @@ class Point {
 }
 
 class Rectangle {
-  constructor(x, y, w, h) {
+  constructor(x, y, w, h, data) {
     this.x = x;
     this.y = y;
     this.w = w;
     this.h = h;
+    this.userData = data;
   }
 
   get left() {
@@ -276,10 +277,88 @@ class QuadTree {
       this.southwest.query(range, found);
       this.southeast.query(range, found);
     }
+    
 
     return found;
   }
 
+  delete(range,id) {
+
+
+    if (!range.intersects(this.boundary)) {
+      return
+    }
+
+
+    for( var i = 0; i < this.points.length; i++ ){
+      var p = this.points[i]
+      if (range.contains(p)) {
+        if(p.userData.id == id){
+          this.points.splice(i,1);
+        }
+      }
+    }
+
+    if (this.divided) {
+      this.northwest.delete(range, id);
+      this.northeast.delete(range, id);
+      this.southwest.delete(range, id);
+      this.southeast.delete(range, id);
+    }
+  }
+
+  movePoint(range,id,x,y) {
+
+
+    if (!range.intersects(this.boundary)) {
+      return
+    }
+
+
+    for( var i = 0; i < this.points.length; i++ ){
+      var p = this.points[i]
+      if (range.contains(p)) {
+        if(p.userData.id == id){
+          this.points[i].x = x;
+          this.points[i].y = y;
+        }
+      }
+    }
+
+    if (this.divided) {
+      this.northwest.movePoint(range,id,x,y);
+      this.northeast.movePoint(range,id,x,y);
+      this.southwest.movePoint(range,id,x,y);
+      this.southeast.movePoint(range,id,x,y);
+    }
+  }
+
+  deleteInRange(range) {
+    //Index of what needs to be deleted
+    var deleteArray = [];
+
+    for( var i = 0; i < this.points.length; i++ ){
+      var p = this.points[i]
+      if (range.contains(p)) {
+        deleteArray.push(i)
+      }
+    }
+
+    //When deleted all index change , so the delta fix it
+    var delta = 0
+    for(var i = 0; i < deleteArray.length; i++){
+      this.points.splice(i-delta,1);
+      delta++
+    }
+
+    if (this.divided) {
+      this.northwest.deleteInRange(range);
+      this.northeast.deleteInRange(range);
+      this.southwest.deleteInRange(range);
+      this.southeast.deleteInRange(range);
+    }
+  }
+    
   closest(point, count, maxDistance) {
     if (typeof point === "undefined") {
       throw TypeError("Method 'closest' needs a point");

--- a/quadtree.js
+++ b/quadtree.js
@@ -177,6 +177,18 @@ class QuadTree {
     }
   }
 
+  clear() {
+    this.points = [];
+
+    if (this.divided) {
+      this.divided = false;
+      delete this.northwest;
+      delete this.northeast;
+      delete this.southwest;
+      delete this.southeast;
+    }
+  }
+
   static create() {
     let DEFAULT_CAPACITY = 8;
     if (arguments.length === 0) {
@@ -332,79 +344,23 @@ class QuadTree {
       this.southeast.query(range, found);
     }
 
-
     return found;
   }
 
-  delete(range,id) {
-    if (!range.intersects(this.boundary)) {
-      return
-    }
-
-
-    for( var i = 0; i < this.points.length; i++ ){
-      var p = this.points[i]
-      if (range.contains(p)) {
-        if(p.userData.id == id){
-          this.points.splice(i,1);
-        }
-      }
-    }
-
-    if (this.divided) {
-      this.northwest.delete(range, id);
-      this.northeast.delete(range, id);
-      this.southwest.delete(range, id);
-      this.southeast.delete(range, id);
-    }
-  }
-
-  movePoint(range,id,x,y) {
-    if (!range.intersects(this.boundary)) {
-      return;
-    }
-
-    for( var i = 0; i < this.points.length; i++ ){
-      var p = this.points[i]
-      if (range.contains(p)) {
-        if(p.userData.id == id){
-          this.points[i].x = x;
-          this.points[i].y = y;
-        }
-      }
-    }
-
-    if (this.divided) {
-      this.northwest.movePoint(range,id,x,y);
-      this.northeast.movePoint(range,id,x,y);
-      this.southwest.movePoint(range,id,x,y);
-      this.southeast.movePoint(range,id,x,y);
-    }
-  }
-
   deleteInRange(range) {
-    //Index of what needs to be deleted
-    var deleteArray = [];
-
-    for( var i = 0; i < this.points.length; i++ ){
-      var p = this.points[i]
-      if (range.contains(p)) {
-        deleteArray.push(i)
-      }
-    }
-
-    //When deleted all index change , so the delta fix it
-    var delta = 0
-    for(var i = 0; i < deleteArray.length; i++){
-      this.points.splice(i-delta,1);
-      delta++
-    }
-
     if (this.divided) {
       this.northwest.deleteInRange(range);
       this.northeast.deleteInRange(range);
       this.southwest.deleteInRange(range);
       this.southeast.deleteInRange(range);
+    }
+
+    // Delete points with range
+    for(let i = this.points.length; --i;) {
+      var p = this.points[i];
+      if (range.contains(p)) {
+        this.points.splice(i, 1);
+      }
     }
   }
 
@@ -461,6 +417,18 @@ class QuadTree {
       this.southeast.forEach(fn);
       this.southwest.forEach(fn);
     }
+  }
+
+  filter(fn) {
+    let filtered = new QuadTree(this.boundary, this.capacity);
+
+    this.forEach((point) => {
+      if (fn(point)) {
+        filtered.insert(point);
+      }
+    });
+
+    return filtered;
   }
 
   merge(other, capacity) {

--- a/quadtree.js
+++ b/quadtree.js
@@ -357,8 +357,7 @@ class QuadTree {
 
     // Delete points with range
     for(let i = this.points.length; --i;) {
-      var p = this.points[i];
-      if (range.contains(p)) {
+      if (range.contains(this.points[i])) {
         this.points.splice(i, 1);
       }
     }

--- a/quadtree.js
+++ b/quadtree.js
@@ -356,11 +356,7 @@ class QuadTree {
     }
 
     // Delete points with range
-    for(let i = this.points.length; --i;) {
-      if (range.contains(this.points[i])) {
-        this.points.splice(i, 1);
-      }
-    }
+    this.points = this.points.filter(point => !range.contains(point));
   }
 
   closest(searchPoint, maxCount = 1, maxDistance = Infinity) {

--- a/test/quadtree.delete.spec.js
+++ b/test/quadtree.delete.spec.js
@@ -1,0 +1,88 @@
+const { expect } = require("chai");
+const { QuadTree, Point, Rectangle, Circle } = require("../quadtree");
+
+describe("QuadTree.deleteInRange", () => {
+  let qt;
+
+  beforeEach(() => {
+    qt = new QuadTree(new Rectangle(0, 0, 200, 200), 4);
+    qt.insert(new Point(-100, 10));
+    qt.insert(new Point(   0, 10));
+    qt.insert(new Point( 100, 10));
+  });
+
+  it("delete within a Rectangle", () => {
+    qt.deleteInRange(new Rectangle(25, 0, 100, 100)); // delete one
+    expect(qt.length).to.equal(2);
+  });
+  it("delete nothing outside Rectangle", () => {
+    qt.deleteInRange(new Rectangle(25, 100, 1, 1));
+    expect(qt.length).to.equal(3);
+  });
+
+  it("delete within a Circle", () => {
+    qt.deleteInRange(new Circle(0, 0, 50, 50)); // delete one
+    expect(qt.length).to.equal(2);
+  });
+  it("delete nothing outside Circle", () => {
+    qt.deleteInRange(new Circle(25, 100, 1, 1));
+    expect(qt.length).to.equal(3);
+  });
+});
+
+describe("QuadTree.filter", () => {
+  beforeEach(() => {
+    qt = new QuadTree(new Rectangle(0, 0, 200, 200), 2);
+    qt.insert(new Point(-100, 10));
+    qt.insert(new Point(   0, 10));
+    qt.insert(new Point( 100, 10));
+  });
+
+  it("will filter all", () => {
+    const filtered = qt.filter((point) => false);
+    expect(filtered.length).to.equal(0);
+  });
+  it("will filter none", () => {
+    const filtered = qt.filter((point) => true);
+    expect(filtered.length).to.equal(3);
+  });
+  it("will filter some", () => {
+    const filtered = qt.filter((point) => point.x === 0);
+    expect(filtered.length).to.equal(1);
+  });
+
+  it("does not alter the original", () => {
+    const original = qt.toJSON();
+    qt.filter((point) => point.x === 0);
+    expect(qt.toJSON()).to.deep.equal(original);
+  });
+});
+
+describe("QuadTree.clear", () => {
+  let qt;
+
+  beforeEach(() => {
+    qt = new QuadTree(new Rectangle(0, 0, 200, 200), 2);
+    qt.insert(new Point(-100, 10));
+    qt.insert(new Point(   0, 10));
+    qt.insert(new Point( 100, 10));
+  });
+
+  it("clears points", () => {
+    expect(qt.length).to.equal(3);
+    qt.clear();
+    expect(qt.length).to.equal(0);
+  });
+
+  it("resets division", () => {
+    expect(qt.divided).to.be.true;
+    qt.clear();
+    expect(qt.divided).to.be.false;
+  });
+
+  it("keeps working after clear", () => {
+    qt.clear();
+    qt.insert(new Point(10, 10));
+    expect(qt.length).to.equal(1);
+  });
+});


### PR DESCRIPTION
This work updates #42 (with many thanks to @AndreAzevedoCoder) with bits from #12 (many thanks to @edenkl8 and @Dezzles)!

- `deleteInRange(range)` - delete all points inside of range.
- `filter(fn)` - works like `Array.filter()`: returns a new QuadTree with only the points that return true.
- `clear()` - removes all points and children from a QuadTree.

Closes #9, #41.